### PR TITLE
fix error checking of the client.Do()

### DIFF
--- a/server/com.appsoulute/goxcors.go
+++ b/server/com.appsoulute/goxcors.go
@@ -52,6 +52,10 @@ func runProxy(client *http.Client, r *http.Request, c Context) string {
 	}
 
 	resp, err := client.Do(req)
+	if err != nil {
+		c.Errorf("Response Error : %q ", err)
+		return fmt.Sprintf("{'err':'%q'}", err)
+	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
client.Do()에 대한 에러체크를 하지 않으면 어떤 에러 상황에 resp가 nil이 리턴될 수 있습니다. 그러면 아래 resp를 참조하는 곳에서 "invalid memory address or nil pointer dereference" 라는 런타임 에러가 발생할 수 있는데요. 이게 GAE의 인스턴스를 죽이는지는 잘 모르겠습니다.

어쨌든 체크를 해주는 게 좋을 것 같은데, 에러 처리 코드가 두 번 중복되는 건 좀 눈에 거슬리긴 하네요. ^^;;
